### PR TITLE
feature/fix work log remove

### DIFF
--- a/app/components/full-calendar.js
+++ b/app/components/full-calendar.js
@@ -359,20 +359,29 @@ export default class FullCalendarComponent extends Component {
   async deleteWorkLog(workLog) {
     this.clearPopovers();
 
-    const workLogCopy = {
-      date: workLog.date,
-      duration: { ...workLog.duration },
-      task: await workLog.task,
-      person: await workLog.person,
-      timesheet: await workLog.timesheet,
-    };
+    // Remove the event visually
+    this.calendar
+      .getEvents()
+      .find(event => event.extendedProps.workLog === workLog)
+      ?.remove();
 
     this.toaster.actionWithUndo({
       actionText: 'Deleting work log…',
       actionDoneText: 'Work log deleted.',
       actionUndoneText: 'Work log restored.',
-      action: async () => await this.args.onDeleteWorkLog?.(workLog),
-      undoAction: async () =>
+      action: async () => {
+        const workLogCopy = {
+          date: workLog.date,
+          duration: { ...workLog.duration },
+          task: await workLog.task,
+          person: await workLog.person,
+          timesheet: await workLog.timesheet,
+        };
+
+        await this.args.onDeleteWorkLog?.(workLog)
+        return workLogCopy;
+      },
+      undoAction: async (workLogCopy) =>
         await this.args.onUndoDeleteWorkLog?.(workLogCopy),
       undoTime: 4000,
       contextKey: 'event-edit-actions',

--- a/app/services/toaster.js
+++ b/app/services/toaster.js
@@ -53,7 +53,8 @@ export default class ToasterService extends Service {
     this.closeBy((toast) => toast.contextKey === contextKey);
     const actionToast = { message: actionText, contextKey, options: {} };
     this.displayToast.perform(actionToast);
-    await action();
+    // Save the return value to pass it to the undo action
+    const actionReturnValue = await action();
     // If the toast was already closed by someone else
     // we don't show any follow up toasts (sorry, hacky)
     if (!this.toasts.includes(actionToast)) return;
@@ -70,7 +71,7 @@ export default class ToasterService extends Service {
           options: {},
         };
         this.displayToast.perform(undoingToast);
-        await undoAction();
+        await undoAction(actionReturnValue);
         // If the toast was already closed by someone else
         // we don't show any follow up toasts (sorry, hacky)
         if (!this.toasts.includes(undoingToast)) return;


### PR DESCRIPTION
When a work log is removed, it should dissappear from the UI immediately. Then the toast should be displayed while the copy is made and the record removed.
This PR implements this behavior
