### PR TITLE
redirect from login when already active session

### DIFF
--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 
 export default class LoginRoute extends Route {
   @service session;
+
   beforeModel() {
     this.session.prohibitAuthentication('index');
   }

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -3,11 +3,7 @@ import { service } from '@ember/service';
 
 export default class LoginRoute extends Route {
   @service session;
-  @service router;
-
-  async beforeModel() {
-    if (this.session.isAuthenticated) {
-      this.router.transitionTo('index');
-    }
+  beforeModel() {
+    this.session.prohibitAuthentication('index');
   }
 }

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,3 +1,13 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
-export default class LoginRoute extends Route {}
+export default class LoginRoute extends Route {
+  @service session;
+  @service router;
+
+  async beforeModel() {
+    if (this.session.isAuthenticated) {
+      this.router.transitionTo('index');
+    }
+  }
+}


### PR DESCRIPTION
Redirect to index from login when already active session. To be tested.

Couldn't test quickly since login fails in my local build (probably some Node version difference. Builds fine, but something seems missing).
First attempt results in a console log: `WARNING: right-hand side of 'in' should be an object, got undefined`
second login attemp results in console log: `WARNING: ember_mu_login_authenticators_mu_semtech__WEBPACK_IMPORTED_MODULE_0__ is undefined`