### PR TITLE
feature/better multi day selection

### DIFF
--- a/app/components/duration-input.js
+++ b/app/components/duration-input.js
@@ -43,10 +43,8 @@ const blurListener = (event) => {
   const element = event.target;
   try {
     const duration = getDurationFromString(element.value);
-    if (!duration) {
-      return;
-    } else {
-      const { hours, minutes } = getDurationFromString(element.value);
+    if (duration) {
+      const { hours, minutes } = duration;
       element.value = `${hours}h${minutes}m`;
       element.setCustomValidity('');
     }

--- a/app/components/duration-input.js
+++ b/app/components/duration-input.js
@@ -11,7 +11,7 @@ const getDurationFromString = (input) => {
   }
 
   if (!input) {
-    return result;
+    return null;
   }
 
   // Check for fractional hours (e.g., "1.5")
@@ -42,9 +42,14 @@ const getDurationFromString = (input) => {
 const blurListener = (event) => {
   const element = event.target;
   try {
-    const { hours, minutes } = getDurationFromString(element.value);
-    element.value = `${hours}h${minutes}m`;
-    element.setCustomValidity('');
+    const duration = getDurationFromString(element.value);
+    if (!duration) {
+      return;
+    } else {
+      const { hours, minutes } = getDurationFromString(element.value);
+      element.value = `${hours}h${minutes}m`;
+      element.setCustomValidity('');
+    }
   } catch (e) {
     element.setCustomValidity(e.message);
     element.reportValidity(false);
@@ -62,6 +67,10 @@ export default class DurationInput extends Component {
   });
 
   get textValue() {
+    if (!this.value) {
+      return '';
+    }
+
     const { hours, minutes } = this.value;
     return `${hours}h${minutes}m`;
   }
@@ -74,6 +83,8 @@ export default class DurationInput extends Component {
     try {
       const newValue = getDurationFromString(value);
       this.args.onChange?.(newValue);
-    } catch (e) {}
+    } catch (e) {
+      /* No problem */
+    }
   };
 }

--- a/app/components/full-calendar.hbs
+++ b/app/components/full-calendar.hbs
@@ -13,10 +13,7 @@
       @workLogs={{this.workLogsForSelection}}
       @onSave={{this.save}}
       @onCancel={{this.cancel}}
-      @isOverwrite={{and
-        this.isMultiDaySelection
-        this.workLogsForSelection
-      }}
+      @isMultiDaySelection={{this.isMultiDaySelection}}
     />
   {{/if}}
 {{/if}}

--- a/app/components/full-calendar.js
+++ b/app/components/full-calendar.js
@@ -196,11 +196,8 @@ export default class FullCalendarComponent extends Component {
     );
     if (workLogs.length) {
       const totalDuration = workLogs
-      .map((workLog) => workLog.duration)
-      .reduce(
-        (acc, duration) => acc.add(duration),
-        new Duration(),
-      );
+        .map((workLog) => workLog.duration)
+        .reduce((acc, duration) => acc.add(duration), new Duration());
       const { hours, minutes } = totalDuration.normalized();
 
       return {

--- a/app/components/time-log-popover.hbs
+++ b/app/components/time-log-popover.hbs
@@ -1,6 +1,6 @@
 <Popover
   {{on "keydown" this.handleKeydown}}
-  class="work-log-popover animate-fly-right w-96 shadow-xl"
+  class="work-log-popover w-96 animate-fly-right shadow-xl"
   @anchorElement={{@anchorElement}}
   @middleware={{this.floatingUIMiddleware}}
 >
@@ -54,20 +54,22 @@
                     <div class="ml-2 mr-1 flex grow flex-col gap-1">
                       <span class="text-sm">{{task-name task}}</span>
                       {{#let (unique-id) as |textAreaId|}}
-                        <textarea
-                          {{spellcheck-on-focus}}
-                          {{dynamic-textarea-height}}
-                          {{on
-                            "input"
-                            (with-value (fn (set workLogEntry "note")))
-                          }}
-                          name="Notes"
-                          id={{textAreaId}}
-                          class="{{if workLogEntry.note 'visible' 'hidden'}}
-                            w-full resize-none rounded border-none p-0 px-0.5 py-0.5 text-xs text-gray-600 placeholder:text-xs placeholder:text-gray-400 hover:bg-gray-100 focus:inline-block focus:bg-white focus:ring-0 group-hover:inline-block"
-                          placeholder="Add notes"
-                          rows="1"
-                        >{{workLogEntry.note}}</textarea>
+                        {{#unless @isMultiDaySelection}}
+                          <textarea
+                            {{spellcheck-on-focus}}
+                            {{dynamic-textarea-height}}
+                            {{on
+                              "input"
+                              (with-value (fn (set workLogEntry "note")))
+                            }}
+                            name="Notes"
+                            id={{textAreaId}}
+                            class="{{if workLogEntry.note 'visible' 'hidden'}}
+                              w-full resize-none rounded border-none p-0 px-0.5 py-0.5 text-xs text-gray-600 placeholder:text-xs placeholder:text-gray-400 hover:bg-gray-100 focus:inline-block focus:bg-white focus:ring-0 group-hover:inline-block"
+                            placeholder="Add notes"
+                            rows="1"
+                          >{{workLogEntry.note}}</textarea>
+                        {{/unless}}
                       {{/let}}
                     </div>
                   </div>
@@ -77,6 +79,7 @@
                       @value={{workLogEntry.duration}}
                       @onChange={{fn this.updateDuration workLogEntry}}
                       {{focus-select (eq this.focusedTaskId task.id)}}
+                      @isRequired={{false}}
                     />
                   {{/let}}
                 </div>
@@ -112,7 +115,7 @@
             @isLoading={{@onSave.isRunning}}
             @skin="primary"
           >
-            {{if @isOverwrite "Overwrite" "Save"}}
+            Save
           </Button>
         </div>
       </form>

--- a/app/components/time-log-popover.js
+++ b/app/components/time-log-popover.js
@@ -27,16 +27,22 @@ export default class WorkLogPopoverComponent extends Component {
   }
 
   async initWorkLogEntries() {
-    const pinnedWorkLogEntries = this.taskSuggestion.pinnedTasks
-      .map((task) => new WorkLogEntry('pinned', task));
+    const pinnedWorkLogEntries = this.taskSuggestion.pinnedTasks.map(
+      (task) => new WorkLogEntry('pinned', task),
+    );
     const mostUsedWorkLogEntries = this.taskSuggestion.mostUsedTasks
-      .filter((mostUsedTask) => !this.taskSuggestion.pinnedTasks.includes(mostUsedTask))
+      .filter(
+        (mostUsedTask) =>
+          !this.taskSuggestion.pinnedTasks.includes(mostUsedTask),
+      )
       .map((task) => new WorkLogEntry('recent', task));
     const workLogEntries = [...pinnedWorkLogEntries, ...mostUsedWorkLogEntries];
 
     for (const workLog of this.args.workLogs) {
       const task = await workLog.task;
-      const workLogEntry = workLogEntries.find((entry) => entry.task.id == task.id);
+      const workLogEntry = workLogEntries.find(
+        (entry) => entry.task.id == task.id,
+      );
       if (workLogEntry) {
         workLogEntry.workLog = workLog;
         workLogEntry.duration = workLog.duration;
@@ -58,7 +64,9 @@ export default class WorkLogPopoverComponent extends Component {
   }
 
   get sortedWorkLogEntries() {
-    return this.workLogEntries.slice(0).sort((a, b) => compare(a.priority, b.priority));
+    return this.workLogEntries
+      .slice(0)
+      .sort((a, b) => compare(a.priority, b.priority));
   }
 
   get visibleTasks() {
@@ -80,7 +88,9 @@ export default class WorkLogPopoverComponent extends Component {
   unpinTask(workLogEntry) {
     if (workLogEntry.type == 'pinned') {
       const { task } = workLogEntry;
-      workLogEntry.type = this.taskSuggestion.mostUsedTasks.includes(task) ? 'recent' : 'added';
+      workLogEntry.type = this.taskSuggestion.mostUsedTasks.includes(task)
+        ? 'recent'
+        : 'added';
       this.taskSuggestion.unpinTask(task);
     } else {
       // not pinned. Nothing must happen.
@@ -89,7 +99,9 @@ export default class WorkLogPopoverComponent extends Component {
 
   @action
   addWorkLogEntry(task) {
-    const workLogEntry = this.workLogEntries.find((workLogEntry) => workLogEntry.task == task);
+    const workLogEntry = this.workLogEntries.find(
+      (workLogEntry) => workLogEntry.task == task,
+    );
     if (!workLogEntry) {
       this.workLogEntries.push(new WorkLogEntry('added', task));
     }
@@ -114,7 +126,7 @@ export default class WorkLogPopoverComponent extends Component {
     // - an existing workLog record (existing workLog that needs to be updated)
     // - a duration that is > 0 (new workLog that need to be created)
     const changedWorkLogEntries = this.workLogEntries.filter(
-      (workLogEntry) => workLogEntry.workLog || workLogEntry.hasDuration
+      (workLogEntry) => workLogEntry.workLog || workLogEntry.hasDuration,
     );
     this.args.onSave?.perform(changedWorkLogEntries);
   }

--- a/app/components/time-log-popover.js
+++ b/app/components/time-log-popover.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { TrackedArray } from 'tracked-built-ins';
 import { compare } from '@ember/utils';
 import WorkLogEntry from '../utils/work-log-entry';
+import Duration from '../utils/duration';
 import { offset } from '@floating-ui/dom';
 
 export default class WorkLogPopoverComponent extends Component {
@@ -28,14 +29,14 @@ export default class WorkLogPopoverComponent extends Component {
 
   async initWorkLogEntries() {
     const pinnedWorkLogEntries = this.taskSuggestion.pinnedTasks.map(
-      (task) => new WorkLogEntry('pinned', task),
+      (task) => new WorkLogEntry('pinned', task, new Duration()),
     );
     const mostUsedWorkLogEntries = this.taskSuggestion.mostUsedTasks
       .filter(
         (mostUsedTask) =>
           !this.taskSuggestion.pinnedTasks.includes(mostUsedTask),
       )
-      .map((task) => new WorkLogEntry('recent', task));
+      .map((task) => new WorkLogEntry('recent', task, new Duration()));
     const workLogEntries = [...pinnedWorkLogEntries, ...mostUsedWorkLogEntries];
 
     for (const workLog of this.args.workLogs) {
@@ -44,11 +45,12 @@ export default class WorkLogPopoverComponent extends Component {
         (entry) => entry.task.id == task.id,
       );
       if (workLogEntry) {
-        workLogEntry.workLog = workLog;
-        workLogEntry.duration = workLog.duration;
-        workLogEntry.note = workLog.note;
+        workLogEntry.duration = this.args.isMultiDaySelection
+          ? null
+          : workLog.duration;
+        workLogEntry.note = this.args.isMultiDaySelection ? null : workLog.note;
       } else {
-        workLogEntries.push(new WorkLogEntry('added', task, workLog));
+        workLogEntries.push(new WorkLogEntry('added', task, workLog.duration));
       }
     }
 
@@ -103,7 +105,7 @@ export default class WorkLogPopoverComponent extends Component {
       (workLogEntry) => workLogEntry.task == task,
     );
     if (!workLogEntry) {
-      this.workLogEntries.push(new WorkLogEntry('added', task));
+      this.workLogEntries.push(new WorkLogEntry('added', task, new Duration()));
     }
     this.focusedTaskId = task.id;
   }
@@ -122,13 +124,7 @@ export default class WorkLogPopoverComponent extends Component {
   @action
   submitWorkLogs(event) {
     event.preventDefault();
-    // Only pass workLogEntries that have either:
-    // - an existing workLog record (existing workLog that needs to be updated)
-    // - a duration that is > 0 (new workLog that need to be created)
-    const changedWorkLogEntries = this.workLogEntries.filter(
-      (workLogEntry) => workLogEntry.workLog || workLogEntry.hasDuration,
-    );
-    this.args.onSave?.perform(changedWorkLogEntries);
+    this.args.onSave?.perform(this.workLogEntries);
   }
 
   @action

--- a/app/controllers/year/month.js
+++ b/app/controllers/year/month.js
@@ -37,75 +37,63 @@ export default class YearMonthContoller extends Controller {
   }
 
   save = ecTask(async (workLogEntries, dates) => {
-    // Selection only contains one date, we don't want to overwrite
-    if (dates.length === 1) {
-      await Promise.all(
-        workLogEntries.map(async ({ duration, task, workLog, note }) => {
-          if (workLog) {
-            if (duration.hours === 0 && duration.minutes === 0) {
-              // An existing worklog was set to 0, remove it
-              await workLog.destroyRecord();
-              this.model.workLogs.removeObject(workLog);
-            } else {
-              // Properties of an existing workLog have changed
-              workLog.duration = duration;
-              workLog.task = task;
-              workLog.note = note;
-              await workLog.save();
+    // This list is needed because otherwise UI will update
+    // After every delete
+    const workLogsToRemove = [];
+    await Promise.all([
+      ...dates.map(async (date) => {
+        await Promise.all(
+          workLogEntries.map(async ({ duration, task, note }) => {
+            if (!duration) {
+              return;
             }
-          } else {
-            // A new workLog has to be created
-            const [date] = dates;
-            const newWorkLog = this.store.createRecord('work-log', {
-              duration,
-              task,
-              date,
-              note,
-              person: this.userProfile.user,
-            });
-            await newWorkLog.save();
-          }
-        }),
-      );
-    } else {
-      // This list is needed because otherwise UI will update
-      // After every delete
-      const workLogsToRemove = [];
-      await Promise.all([
-        // Clear existing workLogs
-        ...this.model.workLogs.map(async (workLog) => {
-          if (dates.some((date) => isSameDay(date, workLog.date))) {
-            await workLog.destroyRecord();
-            workLogsToRemove.push(workLog);
-          }
-        }),
-        // Insert new workLogs
-        ...dates.map(async (date) => {
-          await Promise.all(
-            workLogEntries
-              .filter(
-                ({ duration: { hours, minutes } }) => hours > 0 || minutes > 0,
-              )
-              .map(async ({ duration, task, note }) => {
-                // A new workLog has to be created
-                const newWorkLog = this.store.createRecord('work-log', {
-                  duration,
-                  task,
-                  note,
-                  date,
-                  person: this.userProfile.user,
-                });
-                await newWorkLog.save();
-              }),
-          );
-        }),
-      ]);
-      workLogsToRemove.forEach((workLog) =>
-        this.model.workLogs.removeObject(workLog),
-      );
-    }
+            const workLog = await this.findWorkLog(task.id, date);
+            if (workLog) {
+              if (duration.isEmpty) {
+                await workLog.destroyRecord();
+                workLogsToRemove.push(workLog);
+              } else {
+                workLog.duration = duration;
+                await workLog.save();
+              }
+            } else if (!duration.isEmpty) {
+              const newWorkLog = this.store.createRecord('work-log', {
+                duration,
+                task,
+                note,
+                date,
+                person: this.userProfile.user,
+              });
+              await newWorkLog.save();
+            }
+          }),
+        );
+      }),
+    ]);
+    workLogsToRemove.forEach((workLog) =>
+      this.model.workLogs.removeObject(workLog),
+    );
     this.router.refresh(this.router.currentRouteName);
   });
+
+  /**
+   * Finds a WorkLog by taskId and date by which it is uniquely defined
+   * @param {string} taskId
+   * @param {Date} date
+   * @returns WorkLog
+   */
+  async findWorkLog(taskId, date) {
+    const workLogsWithTasks = await Promise.all(
+      this.model.workLogs.map(async (workLog) => ({
+        workLog,
+        task: await workLog.task,
+      })),
+    );
+    return workLogsWithTasks.find(
+      ({ workLog, task }) =>
+        isSameDay(workLog.date, date) && taskId === task.id,
+    )?.workLog;
+  }
 
   @action
   async deleteWorkLog(workLog) {

--- a/app/utils/work-log-entry.js
+++ b/app/utils/work-log-entry.js
@@ -7,18 +7,18 @@ import { tracked } from '@glimmer/tracking';
  * Its task and duration properties are not kept in sync with the task/duration of this object.
  */
 export default class WorkLogEntry {
+  ALLOWED_TYPES = ['pinned', 'recent', 'added'];
   @tracked type; // one of 'pinned', 'recent', 'added'
   @tracked task;
-  @tracked workLog;
   @tracked duration;
   @tracked note;
 
-  constructor(type, task, workLog) {
+  constructor(type, task, duration = null, note = null) {
+    this._checkType(type);
     this.type = type;
     this.task = task;
-    this.workLog = workLog;
-    this.duration = workLog?.duration || { hours: 0, minutes: 0 }
-    this.note = workLog?.note || null;
+    this.duration = duration;
+    this.note = note;
   }
 
   get hasDuration() {
@@ -27,5 +27,13 @@ export default class WorkLogEntry {
 
   get priority() {
     return this.type == 'pinned' ? 1 : this.type == 'recent' ? 2 : 3;
+  }
+
+  _checkType(type) {
+    if (!this.ALLOWED_TYPES.includes(type)) {
+      throw new Error(
+        `Type must be one of: ${JSON.stringify(this.ALLOWED_TYPES)}`,
+      );
+    }
   }
 }


### PR DESCRIPTION
With the current implementation of multi-day selections, all logs will be overriden by the durations inputted in the work-log-popover component. This behavior is confusing as remarked here: https://github.com/redpencilio/frontend-timekeeper/issues/33

This PR solves the problem by only saving logs where the user has changed anything to the duration.

## New Multi Day Selection Behavior
### Previous
(see https://github.com/redpencilio/frontend-timekeeper/issues/33)
### New
Selecting a range where a work log is already present should leave the duration for that task empty in the work-log-popover.
<img width="2630" height="670" alt="image" src="https://github.com/user-attachments/assets/3bb5c189-5583-447f-97c0-81f12e92daef" />

Filling in a duration for another task
<img width="2626" height="638" alt="image" src="https://github.com/user-attachments/assets/79249b64-183d-4fde-8974-2ae044e6da19" />
Results in the following:
<img width="1816" height="226" alt="image" src="https://github.com/user-attachments/assets/e2df507c-f05f-4b19-a290-0beea7fde454" />
Note that if the duration for LBLOD was filled in as well (value: 4h) this would result in the following
<img width="1838" height="214" alt="image" src="https://github.com/user-attachments/assets/27e7d874-6071-4e87-b585-4ba298048ab1" />


## How to test
All single day selection functionality should still work as expected.
Multi day selections should follow new additive behavior.

